### PR TITLE
More tweaks to the start-virtac script.

### DIFF
--- a/virtac/Pipfile
+++ b/virtac/Pipfile
@@ -8,5 +8,6 @@ name = "pypi"
 [packages]
 # pyAT 0.0.2 requires numpy 1.16 due to a bug, despite claiming support
 # for 1.10 and up.
+cothread = "*"
 numpy = ">=1.16.0,<1.17"
 accelerator-toolbox = ">=0.0.2"

--- a/virtac/start-virtac
+++ b/virtac/start-virtac
@@ -9,6 +9,8 @@ PYIOC=/dls_sw/prod/$EPICS_VERSION/support/pythonIoc/$PYIOC_VERSION/pythonIoc
 export HERE=$(dirname $PYIOC)
 export PYTHONPATH=$PYTHONPATH:$HERE/python
 
+unset PIPENV_PYPI_MIRROR
+
 # We need Pipenv only because there is one dependency that is not already
 # installed inside Diamond. The other dependencies are brought in through
 # --site-packages.


### PR DESCRIPTION
It intends to allow starting the virtual accelerator inside the DLS
Controls environment, but it is brittle.