### PR TITLE
We always want the lattice energy in eV

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ description = "Accelerator Toolbox Interface for Pytac"
 dependencies = [
     "numpy",
     "scipy",
-    "pytac>=0.3.0",
+    "pytac>=0.6.1",
     "accelerator-toolbox (>=0.2.0,<0.7.1)",
     "cothread",
     "softioc",

--- a/src/atip/load_sim.py
+++ b/src/atip/load_sim.py
@@ -32,7 +32,7 @@ def load_from_filepath(
     at_lattice = at.load.load_mat(
         at_lattice_filepath,
         name=pytac_lattice.name,
-        energy=pytac_lattice.get_value("energy"),
+        energy=pytac_lattice.get_value("energy", units=pytac.PHYS),
     )
     return load(pytac_lattice, at_lattice, callback, disable_emittance)
 

--- a/src/atip/utils.py
+++ b/src/atip/utils.py
@@ -50,7 +50,7 @@ def loader(mode="I04", callback=None, disable_emittance=False):
     at_lattice = load_at_lattice(
         mode,
         periodicity=1,
-        energy=pytac_lattice.get_value("energy"),
+        energy=pytac_lattice.get_value("energy", units=pytac.PHYS),
     )
     lattice = atip.load_sim.load(pytac_lattice, at_lattice, callback, disable_emittance)
     return lattice


### PR DESCRIPTION
Corresponding change for https://github.com/DiamondLightSource/pytac/pull/144, so tests will fail until that is merged